### PR TITLE
model now use shared ptr + cache system to spare memory

### DIFF
--- a/lib/Ray/sources/Drawables/2D/Circle.cpp
+++ b/lib/Ray/sources/Drawables/2D/Circle.cpp
@@ -6,6 +6,7 @@
 */
 
 #include "Drawables/2D/Circle.hpp"
+#include "Drawables/Image.hpp"
 
 namespace RAY::Drawables::Drawables2D
 {

--- a/lib/Ray/sources/Drawables/2D/Line.cpp
+++ b/lib/Ray/sources/Drawables/2D/Line.cpp
@@ -7,6 +7,7 @@
 
 #include "Drawables/2D/Line.hpp"
 #include <cmath>
+#include "Drawables/Image.hpp"
 
 namespace RAY::Drawables::Drawables2D
 {

--- a/lib/Ray/sources/Drawables/2D/Point.cpp
+++ b/lib/Ray/sources/Drawables/2D/Point.cpp
@@ -6,6 +6,7 @@
 */
 
 #include "Drawables/2D/Point.hpp"
+#include "Drawables/Image.hpp"
 
 namespace RAY::Drawables::Drawables2D
 {

--- a/lib/Ray/sources/Drawables/2D/Rectangle.cpp
+++ b/lib/Ray/sources/Drawables/2D/Rectangle.cpp
@@ -50,7 +50,7 @@ namespace RAY::Drawables::Drawables2D
 		ImageDrawRectangleV(image, this->_position, this->_dimensions, this->_color);
 	}
 
-	Rectangle::operator  ::Rectangle () const
+	Rectangle::operator  ::Rectangle() const
 	{
 		::Rectangle rect;
 

--- a/lib/Ray/sources/Drawables/2D/Rectangle.cpp
+++ b/lib/Ray/sources/Drawables/2D/Rectangle.cpp
@@ -7,6 +7,7 @@
 
 #include "Drawables/2D/Rectangle.hpp"
 #include <cmath>
+#include "Drawables/Image.hpp"
 
 namespace RAY::Drawables::Drawables2D
 {
@@ -47,5 +48,13 @@ namespace RAY::Drawables::Drawables2D
 	void Rectangle::drawOn(RAY::Image &image)
 	{
 		ImageDrawRectangleV(image, this->_position, this->_dimensions, this->_color);
+	}
+
+	Rectangle::operator  ::Rectangle () const
+	{
+		return (::Rectangle){
+			this->_position.x, this->_position.y,
+			this->_dimensions.x, this->_dimensions.y
+		};
 	}
 }

--- a/lib/Ray/sources/Drawables/2D/Rectangle.cpp
+++ b/lib/Ray/sources/Drawables/2D/Rectangle.cpp
@@ -52,9 +52,12 @@ namespace RAY::Drawables::Drawables2D
 
 	Rectangle::operator  ::Rectangle () const
 	{
-		return (::Rectangle){
-			this->_position.x, this->_position.y,
-			this->_dimensions.x, this->_dimensions.y
-		};
+		::Rectangle rect;
+
+		rect.x = this->_position.x;
+		rect.y = this->_position.y;
+		rect.width = this->_dimensions.x;
+		rect.height = this->_dimensions.y;
+		return rect;
 	}
 }

--- a/lib/Ray/sources/Drawables/2D/Rectangle.hpp
+++ b/lib/Ray/sources/Drawables/2D/Rectangle.hpp
@@ -37,7 +37,7 @@ namespace RAY::Drawables::Drawables2D {
 			Rectangle &operator=(const Rectangle &) = default;
 
 			//! @brief A default destructor
-			~Rectangle() override = default;
+			virtual ~Rectangle() override = default;
 
 			//! @return the dimensions of the rectangle
 			const Vector2 &getDimensions(void);

--- a/lib/Ray/sources/Drawables/2D/Rectangle.hpp
+++ b/lib/Ray/sources/Drawables/2D/Rectangle.hpp
@@ -49,11 +49,11 @@ namespace RAY::Drawables::Drawables2D {
 			Rectangle &setDimensions(int x, int y);
 
 			//! @brief Draw point on window
-			void drawOn(RAY::Window &) override;
+			virtual void drawOn(RAY::Window &) override;
 			//! @brief Draw point on image
-			void drawOn(RAY::Image &image) override;
+			virtual void drawOn(RAY::Image &image) override;
 
-		private:
+		protected:
 			//! @brief Diemnsions of the rectangle 
 			Vector2 _dimensions;
 		

--- a/lib/Ray/sources/Drawables/2D/Rectangle.hpp
+++ b/lib/Ray/sources/Drawables/2D/Rectangle.hpp
@@ -20,7 +20,7 @@ namespace RAY::Drawables::Drawables2D {
 			//! @param position position of top-left point  
 			//! @param dimensions dimensions of the rectangle 
 			//! @param Color Color of the rectangle  
-			Rectangle(const Vector2 &position, const Vector2 &dimensions, const Color &color);
+			Rectangle(const Vector2 &position, const Vector2 &dimensions, const Color &color = WHITE);
 
 			//! @brief Rectangle constructor
 			//! @param x x-position of top-left point  
@@ -28,7 +28,7 @@ namespace RAY::Drawables::Drawables2D {
 			//! @param width width of the rectangle 
 			//! @param length length of the rectangle 
 			//! @param Color Color of the rectangle  
-			Rectangle(int x, int y, int width, int height, const Color &color);
+			Rectangle(int x, int y, int width, int height, const Color &color = WHITE);
 			
 			//! @brief A default copy constructor
 			Rectangle(const Rectangle &) = default;
@@ -56,6 +56,9 @@ namespace RAY::Drawables::Drawables2D {
 		private:
 			//! @brief Diemnsions of the rectangle 
 			Vector2 _dimensions;
+		
+		INTERNAL:
+			operator ::Rectangle() const;
 	};
 };
 

--- a/lib/Ray/sources/Drawables/2D/Text.cpp
+++ b/lib/Ray/sources/Drawables/2D/Text.cpp
@@ -6,7 +6,7 @@
 */
 
 #include "Drawables/2D/Text.hpp"
-
+#include "Drawables/Image.hpp"
 #include <utility>
 
 namespace RAY::Drawables::Drawables2D

--- a/lib/Ray/sources/Drawables/2D/Triangle.cpp
+++ b/lib/Ray/sources/Drawables/2D/Triangle.cpp
@@ -7,6 +7,7 @@
 
 #include "Drawables/2D/Triangle.hpp"
 #include "Exceptions/RayError.hpp"
+#include "Drawables/Image.hpp"
 
 namespace RAY::Drawables::Drawables2D
 {

--- a/lib/Ray/sources/Drawables/ADrawable2D.cpp
+++ b/lib/Ray/sources/Drawables/ADrawable2D.cpp
@@ -6,6 +6,7 @@
 */
 
 #include "Drawables/ADrawable2D.hpp"
+#include "Image.hpp"
 
 namespace RAY::Drawables
 {

--- a/lib/Ray/sources/Drawables/ADrawable2D.hpp
+++ b/lib/Ray/sources/Drawables/ADrawable2D.hpp
@@ -10,10 +10,12 @@
 
 #include <raylib.h>
 #include "Vector/Vector2.hpp"
-#include "Image.hpp"
 #include "Drawables/IDrawable.hpp"
 #include "Color.hpp"
 
+namespace RAY {
+	class Image;
+}
 namespace RAY::Drawables {
 	//! @brief Abstraction of any two-dimensionnal drawable
 	class ADrawable2D: public IDrawable

--- a/lib/Ray/sources/Drawables/Image.cpp
+++ b/lib/Ray/sources/Drawables/Image.cpp
@@ -37,13 +37,13 @@ namespace RAY {
 
 	std::shared_ptr<::Image> Image::fetchImageInCache(const std::string &path)
 	{
-		if (Image::_modelsCache.find(path) == Image::_modelsCache.end())
-			Image::_modelsCache.emplace(path, std::shared_ptr<::Image>(
+		if (Image::_ImageCache.find(path) == Image::_ImageCache.end())
+			Image::_ImageCache.emplace(path, std::shared_ptr<::Image>(
 			new ::Image(LoadImage(path.c_str())), [](::Image *p) {
 	       		UnloadImage(*p);
 	       		delete p;
 	    	}));
-		return _modelsCache[path];
+		return _ImageCache[path];
 	}
 
 	void Image::draw(Drawables::ADrawable2D &drawable)

--- a/lib/Ray/sources/Drawables/Image.cpp
+++ b/lib/Ray/sources/Drawables/Image.cpp
@@ -13,9 +13,10 @@ namespace RAY {
 	std::unordered_map<std::string, std::shared_ptr<::Image>> Image::_modelsCache;
 
 	Image::Image(const std::string &filename):
-		ADrawable2D(Vector2(0, 0), WHITE),
+		Rectangle(Vector2(0, 0), Vector2(0, 0), WHITE),
 		_image(fetchImageInCache(filename))
 	{
+		this->_dimensions = Vector2(this->_image->width, this->_image->height);
 	}
 
 	bool Image::exportTo(const std::string &outputPath)
@@ -33,16 +34,7 @@ namespace RAY {
 	{
 		return this->_image.get();
 	}
-	Image &Image::resize(const Vector2 &dimensions)
-	{
-		ImageResize(this->_image.get(), dimensions.x, dimensions.y);
-		return *this;
-	}
-    
-    Vector2 Image::getDimensions() const
-	{
-		return Vector2(this->_image->width, this->_image->height);
-	}
+
 	std::shared_ptr<::Image> Image::fetchImageInCache(const std::string &path)
 	{
 		if (Image::_modelsCache.find(path) == Image::_modelsCache.end())
@@ -61,9 +53,14 @@ namespace RAY {
 
 	void Image::drawOn(RAY::Window &)
 	{
+		//Since the image is a shared object, when it is resized, it mush be resized after to its previous dimensions
+		Vector2 oldDims = Vector2(this->_image->width, this->_image->height);
+
+		ImageResize(*this, this->_dimensions.x, this->_dimensions.y);
 		Texture texture(*this);
 
 		DrawTexture(texture, this->_position.x, this->_position.y, this->_color); 
+		ImageResize(*this, oldDims.x, oldDims.y);
 	}
 
 	void Image::drawOn(RAY::Image &image)

--- a/lib/Ray/sources/Drawables/Image.cpp
+++ b/lib/Ray/sources/Drawables/Image.cpp
@@ -6,36 +6,71 @@
 */
 
 #include "Drawables/Image.hpp"
-#include "Drawables/IDrawable.hpp"
+#include "Drawables/ADrawable2D.hpp"
+#include "Drawables/2D/Rectangle.hpp"
 
-RAY::Image::Image(const std::string &filename):
-	_image(LoadImage(filename.c_str()))
-{
-}
+namespace RAY {
+	std::unordered_map<std::string, std::shared_ptr<::Image>> Image::_modelsCache;
 
-RAY::Image::Image(RAY::Texture &texture):
-	_image(GetTextureData(texture))
-{
+	Image::Image(const std::string &filename):
+		ADrawable2D(Vector2(0, 0), WHITE),
+		_image(fetchImageInCache(filename))
+	{
+	}
 
-}
+	bool Image::exportTo(const std::string &outputPath)
+	{
+		ExportImage(*this->_image, outputPath.c_str());
+		return true;
+	}
 
-RAY::Image::~Image()
-{
-	UnloadImage(_image);
-}
+	Image::operator ::Image() const
+	{
+		return *this->_image;
+	}
 
-bool RAY::Image::exportTo(const std::string &outputPath)
-{
-	ExportImage(_image, outputPath.c_str());
-	return true;
-}
+	Image::operator ::Image *()
+	{
+		return this->_image.get();
+	}
+	Image &Image::resize(const Vector2 &dimensions)
+	{
+		ImageResize(this->_image.get(), dimensions.x, dimensions.y);
+		return *this;
+	}
+    
+    Vector2 Image::getDimensions() const
+	{
+		return Vector2(this->_image->width, this->_image->height);
+	}
+	std::shared_ptr<::Image> Image::fetchImageInCache(const std::string &path)
+	{
+		if (Image::_modelsCache.find(path) == Image::_modelsCache.end())
+			Image::_modelsCache.emplace(path, std::shared_ptr<::Image>(
+			new ::Image(LoadImage(path.c_str())), [](auto p) {
+	       		UnloadImage(*p);
+	       		delete p;
+	    	}));
+		return _modelsCache[path];
+	}
 
-RAY::Image::operator ::Image() const
-{
-	return _image;
-}
+	void Image::draw(Drawables::ADrawable2D &drawable)
+	{
+		drawable.drawOn(*this);
+	}
 
-RAY::Image::operator ::Image *()
-{
-	return &this->_image;
+	void Image::drawOn(RAY::Window &)
+	{
+		Texture texture(*this);
+
+		DrawTexture(texture, this->_position.x, this->_position.y, this->_color); 
+	}
+
+	void Image::drawOn(RAY::Image &image)
+	{
+		Drawables::Drawables2D::Rectangle dest(this->_position, this->getDimensions());
+		Drawables::Drawables2D::Rectangle src(Vector2(0, 0), this->getDimensions());
+		
+		ImageDraw(image, *this, dest, src, this->_color);
+	}
 }

--- a/lib/Ray/sources/Drawables/Image.cpp
+++ b/lib/Ray/sources/Drawables/Image.cpp
@@ -47,7 +47,7 @@ namespace RAY {
 	{
 		if (Image::_modelsCache.find(path) == Image::_modelsCache.end())
 			Image::_modelsCache.emplace(path, std::shared_ptr<::Image>(
-			new ::Image(LoadImage(path.c_str())), [](auto p) {
+			new ::Image(LoadImage(path.c_str())), [](::Image *p) {
 	       		UnloadImage(*p);
 	       		delete p;
 	    	}));

--- a/lib/Ray/sources/Drawables/Image.cpp
+++ b/lib/Ray/sources/Drawables/Image.cpp
@@ -10,7 +10,7 @@
 #include "Drawables/2D/Rectangle.hpp"
 
 namespace RAY {
-	std::unordered_map<std::string, std::shared_ptr<::Image>> Image::_modelsCache;
+	std::unordered_map<std::string, std::shared_ptr<::Image>> Image::_ImageCache;
 
 	Image::Image(const std::string &filename):
 		Rectangle(Vector2(0, 0), Vector2(0, 0), WHITE),

--- a/lib/Ray/sources/Drawables/Image.hpp
+++ b/lib/Ray/sources/Drawables/Image.hpp
@@ -11,43 +11,55 @@
 #include <raylib.h>
 #include <string>
 #include "Texture.hpp"
+#include <memory>
+#include <unordered_map>
+#include "Drawables/ADrawable2D.hpp"
 
 namespace RAY
 {
-	namespace Drawables {
-		class ADrawable2D;
-	}
 	//! @brief Object representation of a framebuffer
-	class Image {
+	class Image: public Drawables::ADrawable2D {
 		public:
 			//! @brief Create an image, loading a file
 			//! @param filename: path to file to load
 			Image(const std::string &filename);
 
-			//! @brief Create an image, using data from a texure
-			//! @param texture: texture to extract data from
-			Image(Texture &texture);
-
 			//! @brief A default copy constructor
-			Image(const Image &image) = delete;
+			Image(const Image &image) = default;
 
 			//! @brief An image is assignable
-			Image &operator=(const Image &image) = delete;
+			Image &operator=(const Image &image) = default;
 			
 			//! @brief Image destructor, will unload ressources
-			~Image();
+			~Image() = default;
 
 			//! @brief export to file
 			//! @param outputPath: path of output
 			bool exportTo(const std::string &outputPath);
+			//! @brief Resize picture
+            Image &resize(const Vector2 &dimensions);
+            //! @return current sprite dimensions
+            Vector2 getDimensions() const;
 
 
-			//! @brief draw drawable
+			//! @brief draw drawable on image
 			void draw(Drawables::ADrawable2D &);
+
+			//! @brief Draw image on window
+			void drawOn(RAY::Window &) override;
+
+			//! @brief Draw image on another image
+			void drawOn(RAY::Image &image) override;
+
 
 		private:
 			//! @brief Image, really, that's just it...
-			::Image _image;
+			std::shared_ptr<::Image> _image;
+			//! @brief, look through cache to see if a model using same file
+			std::shared_ptr<::Image>fetchImageInCache(const std::string &path);
+
+			static std::unordered_map<std::string, std::shared_ptr<::Image>> _modelsCache;
+
 		
 		INTERNAL:
 			//! @brief get image

--- a/lib/Ray/sources/Drawables/Image.hpp
+++ b/lib/Ray/sources/Drawables/Image.hpp
@@ -31,7 +31,7 @@ namespace RAY
 			Image &operator=(const Image &image) = default;
 			
 			//! @brief Image destructor, will unload ressources
-			~Image() = default;
+			~Image() override = default;
 
 			//! @brief export to file
 			//! @param outputPath: path of output

--- a/lib/Ray/sources/Drawables/Image.hpp
+++ b/lib/Ray/sources/Drawables/Image.hpp
@@ -13,12 +13,12 @@
 #include "Texture.hpp"
 #include <memory>
 #include <unordered_map>
-#include "Drawables/ADrawable2D.hpp"
+#include "Drawables/2D/Rectangle.hpp"
 
 namespace RAY
 {
 	//! @brief Object representation of a framebuffer
-	class Image: public Drawables::ADrawable2D {
+	class Image: public Drawables::Drawables2D::Rectangle {
 		public:
 			//! @brief Create an image, loading a file
 			//! @param filename: path to file to load
@@ -36,11 +36,6 @@ namespace RAY
 			//! @brief export to file
 			//! @param outputPath: path of output
 			bool exportTo(const std::string &outputPath);
-			//! @brief Resize picture
-            Image &resize(const Vector2 &dimensions);
-            //! @return current sprite dimensions
-            Vector2 getDimensions() const;
-
 
 			//! @brief draw drawable on image
 			void draw(Drawables::ADrawable2D &);

--- a/lib/Ray/sources/Drawables/Image.hpp
+++ b/lib/Ray/sources/Drawables/Image.hpp
@@ -53,7 +53,7 @@ namespace RAY
 			//! @brief, look through cache to see if a model using same file
 			std::shared_ptr<::Image>fetchImageInCache(const std::string &path);
 
-			static std::unordered_map<std::string, std::shared_ptr<::Image>> _modelsCache;
+			static std::unordered_map<std::string, std::shared_ptr<::Image>> _ImageCache;
 
 		
 		INTERNAL:

--- a/lib/Ray/sources/Drawables/Texture.cpp
+++ b/lib/Ray/sources/Drawables/Texture.cpp
@@ -23,7 +23,7 @@ namespace RAY {
 
 	Texture::Texture(const Image &image):
 		_texture(LoadTextureFromImage(image)),
-		_resourcePath("IMAGE")
+		_resourcePath()
 	{
 	}
 

--- a/lib/Ray/sources/Drawables/Texture.cpp
+++ b/lib/Ray/sources/Drawables/Texture.cpp
@@ -21,6 +21,12 @@ namespace RAY {
 	{
 	}
 
+	Texture::Texture(const Image &image):
+		_texture(LoadTextureFromImage(image)),
+		_resourcePath("IMAGE")
+	{
+	}
+
 
 	Texture &Texture::operator=(const Texture &other)
 	{

--- a/lib/Ray/sources/Drawables/Texture.hpp
+++ b/lib/Ray/sources/Drawables/Texture.hpp
@@ -20,7 +20,7 @@ namespace RAY
 			//! @param filename: path to file to load
 			Texture(const std::string &filename);
 
-			//! @brief A texture is not constructable
+			//! @brief A texture is copy constructable
 			Texture(const Texture &);
 
 			//! @brief A textrue can be loaded from an image

--- a/lib/Ray/sources/Drawables/Texture.hpp
+++ b/lib/Ray/sources/Drawables/Texture.hpp
@@ -20,10 +20,13 @@ namespace RAY
 			//! @param filename: path to file to load
 			Texture(const std::string &filename);
 
-			//! @brief A texture is not copy constructable
+			//! @brief A texture is not constructable
 			Texture(const Texture &);
 
-			//! @brief An image is assignable
+			//! @brief A textrue can be loaded from an image
+			Texture(const Image &);
+
+			//! @brief An texture is assignable
 			Texture &operator=(const Texture &);
 			
 			//! @brief Texture destructor, will unload ressources

--- a/lib/Ray/sources/Model/Model.cpp
+++ b/lib/Ray/sources/Model/Model.cpp
@@ -110,7 +110,7 @@ namespace RAY::Drawables::Drawables3D {
 	{
 		if (Model::_modelsCache.find(path) == Model::_modelsCache.end())
 			Model::_modelsCache.emplace(path, std::shared_ptr<::Model>(
-			new ::Model(LoadModel(path.c_str())), [](auto p) {
+			new ::Model(LoadModel(path.c_str())), [](::Model *p) {
            		UnloadModel(*p);
            		delete p;
         	}));

--- a/lib/Ray/sources/Model/Model.cpp
+++ b/lib/Ray/sources/Model/Model.cpp
@@ -7,9 +7,12 @@
 
 #include "Model/Model.hpp"
 #include "Exceptions/RayError.hpp"
+#include <unordered_map>
+
 
 namespace RAY::Drawables::Drawables3D {
 
+	std::unordered_map<std::string, std::shared_ptr<::Model>> Model::_modelsCache;
 	Model::Model(const std::string &filename,
 	                                          std::optional<std::pair<MaterialType, std::string>> texture,
 											  const RAY::Vector3 &position,
@@ -17,7 +20,7 @@ namespace RAY::Drawables::Drawables3D {
 											  float rotationAngle,
 											  const RAY::Vector3 &scale)
 		: ADrawable3D(position, WHITE),
-		_model(LoadModel(filename.c_str())),
+		_model(fetchModelInCache(filename)),
 		_rotationAxis(rotationAxis),
 		_rotationAngle(rotationAngle),
 		_scale(scale)
@@ -27,33 +30,29 @@ namespace RAY::Drawables::Drawables3D {
 	}
 
 	Model::Model(const Mesh &mesh)
-	: ADrawable3D({0, 0, 0}, WHITE), _model(LoadModelFromMesh(mesh))
+		: ADrawable3D({0, 0, 0}, WHITE),
+		_model(std::make_shared<::Model>(LoadModelFromMesh(mesh)))
 	{
-	}
-
-	Model::~Model()
-	{
-		UnloadModel(this->_model);
 	}
 
 	bool Model::unloadKeepMeshes()
 	{
-		UnloadModelKeepMeshes(_model);
+		UnloadModelKeepMeshes(*this->_model);
 		return true;
 	}
 
 	bool Model::setAnimation(const RAY::ModelAnimation &animation)
 	{
-		if (!IsModelAnimationValid(this->_model, animation))
+		if (!IsModelAnimationValid(*this->_model, animation))
 			throw RAY::Exception::NotCompatibleError("The animation is not compatible with the model");
-		UpdateModelAnimation(this->_model, animation, animation.getFrameCounter());
+		UpdateModelAnimation(*this->_model, animation, animation.getFrameCounter());
 		return true;
 	}
 
 	bool Model::setTextureToMaterial(Model::MaterialType materialType, const std::string &texturePath)
 	{
 		this->_textureList.emplace(materialType, texturePath);
-		SetMaterialTexture(&this->_model.materials[materialType],
+		SetMaterialTexture(&this->_model->materials[materialType],
 						   materialType,
 						   this->_textureList.at(materialType));
 		return true;
@@ -61,12 +60,12 @@ namespace RAY::Drawables::Drawables3D {
 
 	Model::operator ::Model() const
 	{
-		return this->_model;
+		return *this->_model;
 	}
 
 	int Model::getBoneCount() const
 	{
-		return this->_model.boneCount;
+		return this->_model->boneCount;
 	}
 
 	Model &Model::setRotationAngle(float rotationAngle)
@@ -104,6 +103,17 @@ namespace RAY::Drawables::Drawables3D {
 
 	void Model::drawOn(RAY::Window &)
 	{
-		DrawModelEx(this->_model, this->_position, this->_rotationAxis, this->_rotationAngle, this->_scale, this->_color);
+		DrawModelEx(*this->_model, this->_position, this->_rotationAxis, this->_rotationAngle, this->_scale, this->_color);
+	}
+
+	std::shared_ptr<::Model> Model::fetchModelInCache(const std::string &path)
+	{
+		if (Model::_modelsCache.find(path) == Model::_modelsCache.end())
+			Model::_modelsCache.emplace(path, std::shared_ptr<::Model>(
+			new ::Model(LoadModel(path.c_str())), [](auto p) {
+           		UnloadModel(*p);
+           		delete p;
+        	}));
+		return _modelsCache[path];
 	}
 }

--- a/lib/Ray/sources/Model/Model.hpp
+++ b/lib/Ray/sources/Model/Model.hpp
@@ -44,7 +44,7 @@ namespace RAY::Drawables::Drawables3D {
 			Model& operator=(const Model &model) = default;
 
 			//! @brief Model destructor, model's data will be deleted if it's the last entity alive
-			~Model() = default;
+			~Model() override = default;
 
 			//! @brief Unload model (excluding meshes) from memory (RAM and/or VRAM)
 			bool unloadKeepMeshes();

--- a/lib/Ray/sources/Model/Model.hpp
+++ b/lib/Ray/sources/Model/Model.hpp
@@ -14,7 +14,8 @@
 #include <raylib.h>
 #include <vector>
 #include <optional>
-#include <map>
+#include <unordered_map>
+#include <memory>
 
 namespace RAY::Drawables::Drawables3D {
 	//! @brief Basic 3D Model type
@@ -42,8 +43,8 @@ namespace RAY::Drawables::Drawables3D {
 			//! @brief A model is assignable
 			Model& operator=(const Model &model) = default;
 
-			//! @brief Model destructor, unloads all related data
-			~Model();
+			//! @brief Model destructor, model's data will be deleted if it's the last entity alive
+			~Model() = default;
 
 			//! @brief Unload model (excluding meshes) from memory (RAM and/or VRAM)
 			bool unloadKeepMeshes();
@@ -81,15 +82,19 @@ namespace RAY::Drawables::Drawables3D {
 
 		private:
 			//! @brief Raw data from raylib
-			::Model _model;
+			std::shared_ptr<::Model> _model;
 			//! @brief The list of textures that can be applied to this model.
-			std::map<MaterialType, Texture> _textureList;
+			std::unordered_map<MaterialType, Texture> _textureList;
 			//! @brief Rotation property
 			RAY::Vector3 _rotationAxis;
 			//! @brief Rotation property
 			float _rotationAngle;
 			//! @brief Scale of the shape
 			RAY::Vector3 _scale;
+			//! @brief, look through cache to see if a model using same file
+			std::shared_ptr<::Model>fetchModelInCache(const std::string &path);
+
+			static std::unordered_map<std::string, std::shared_ptr<::Model>> _modelsCache;
 
 		INTERNAL:
 			//! @brief A RAY Model is cast-able in libray's model

--- a/lib/Ray/sources/Window.cpp
+++ b/lib/Ray/sources/Window.cpp
@@ -11,6 +11,7 @@
 #include "Controllers/Mouse.hpp"
 #include "Drawables/ADrawable2D.hpp"
 #include "Drawables/ADrawable3D.hpp"
+#include "Drawables/Image.hpp"
 
 std::optional<RAY::Window> RAY::Window::_instance = std::nullopt;
 

--- a/lib/Ray/sources/Window.hpp
+++ b/lib/Ray/sources/Window.hpp
@@ -11,7 +11,6 @@
 #include <raylib.h>
 #include <string>
 #include <optional>
-#include "Drawables/Image.hpp"
 #include "Vector/Vector2.hpp"
 #include "Vector/Vector3.hpp"
 #include "Controllers/Keyboard.hpp"
@@ -22,6 +21,7 @@
 
 namespace RAY {
 	//! @brief Window manager
+	class Image;
 	namespace Drawables {
 		class IDrawable;
 		class ADrawable3D;


### PR DESCRIPTION
## Proposed changes

Creating a Sprite class, which lets one load a texture, resize it, and draw on a window

Using cache systems for sprites and models  

## Information
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking changes

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation
