### PR TITLE
player models are now independant

### DIFF
--- a/lib/Ray/sources/Model/Model.cpp
+++ b/lib/Ray/sources/Model/Model.cpp
@@ -10,21 +10,23 @@
 #include <unordered_map>
 
 
-namespace RAY::Drawables::Drawables3D {
+namespace RAY::Drawables::Drawables3D
+{
 
 	RAY::Cache<::Model> Model::_modelsCache(LoadModel, UnloadModel);
 
-	Model::Model(const std::string &filename, bool lonely,
-	                                          std::optional<std::pair<MaterialType, std::string>> texture,
-											  const RAY::Vector3 &scale,
-											  const RAY::Vector3 &position,
-											  const RAY::Vector3 &rotationAxis,
-											  float rotationAngle)
+	Model::Model(const std::string &filename,
+	             bool lonely,
+	             std::optional<std::pair<MaterialType, std::string>> texture,
+	             const RAY::Vector3 &scale,
+	             const RAY::Vector3 &position,
+	             const RAY::Vector3 &rotationAxis,
+	             float rotationAngle)
 		: ADrawable3D(position, WHITE),
-		_model(_modelsCache.fetch(filename, lonely)),
-		_rotationAxis(rotationAxis),
-		_rotationAngle(rotationAngle),
-		_scale(scale)
+		  _model(_modelsCache.fetch(filename, lonely)),
+		  _rotationAxis(rotationAxis),
+		  _rotationAngle(rotationAngle),
+		  _scale(scale)
 	{
 		if (texture.has_value())
 			this->setTextureToMaterial(texture->first, texture->second);
@@ -32,7 +34,7 @@ namespace RAY::Drawables::Drawables3D {
 
 	Model::Model(const Mesh &mesh)
 		: ADrawable3D({0, 0, 0}, WHITE),
-		_model(std::make_shared<::Model>(LoadModelFromMesh(mesh)))
+		  _model(std::make_shared<::Model>(LoadModelFromMesh(mesh)))
 	{
 	}
 
@@ -54,8 +56,8 @@ namespace RAY::Drawables::Drawables3D {
 	{
 		this->_textureList.emplace(materialType, texturePath);
 		SetMaterialTexture(&this->_model->materials[materialType],
-						   materialType,
-						   this->_textureList.at(materialType));
+		                   materialType,
+		                   this->_textureList.at(materialType));
 		return true;
 	}
 
@@ -104,7 +106,12 @@ namespace RAY::Drawables::Drawables3D {
 
 	void Model::drawOn(RAY::Window &)
 	{
-		DrawModelEx(*this->_model, this->_position, this->_rotationAxis, this->_rotationAngle, this->_scale, this->_color);
+		DrawModelEx(*this->_model,
+		            this->_position,
+		            this->_rotationAxis,
+		            this->_rotationAngle,
+		            this->_scale,
+		            this->_color);
 	}
 
 	void Model::setShader(const RAY::Shader &shader)

--- a/lib/Ray/sources/Model/Model.cpp
+++ b/lib/Ray/sources/Model/Model.cpp
@@ -14,12 +14,12 @@ namespace RAY::Drawables::Drawables3D {
 
 	RAY::Cache<::Model> Model::_modelsCache(LoadModel, UnloadModel);
 
-	Model::Model(const std::string &filename,
+	Model::Model(const std::string &filename, bool lonely,
 	                                          std::optional<std::pair<MaterialType, std::string>> texture,
 											  const RAY::Vector3 &scale,
 											  const RAY::Vector3 &position,
 											  const RAY::Vector3 &rotationAxis,
-											  float rotationAngle, bool lonely)
+											  float rotationAngle)
 		: ADrawable3D(position, WHITE),
 		_model(_modelsCache.fetch(filename, lonely)),
 		_rotationAxis(rotationAxis),

--- a/lib/Ray/sources/Model/Model.hpp
+++ b/lib/Ray/sources/Model/Model.hpp
@@ -27,12 +27,12 @@ namespace RAY::Drawables::Drawables3D {
 			//! @brief Create an model, loading a file
 			//! @param filePath: path to file to load
 			//! @param lonely: should be set to true if the entity's loaded data must be independant from others
-			Model(const std::string &filePath,
+			Model(const std::string &filePath, bool lonely = false,
 			      std::optional<std::pair<MaterialType, std::string>> texture = std::nullopt,
 				  const RAY::Vector3 &scale = RAY::Vector3(1, 1, 1),
 			      const RAY::Vector3 &position = {0, 0, 0},
 			      const RAY::Vector3 &rotationAxis = RAY::Vector3(0, 1, 0),
-			      float rotationAngle = 0, bool lonely = false);
+			      float rotationAngle = 0);
 
 			//! @brief Create an model, loading a file
 			//! @param mesh: mesh to load

--- a/sources/Component/Keyboard/KeyboardComponent.cpp
+++ b/sources/Component/Keyboard/KeyboardComponent.cpp
@@ -8,15 +8,15 @@
 namespace BBM
 {
 	KeyboardComponent::KeyboardComponent(WAL::Entity &entity,
-							  Key up,
-							  Key down,
-							  Key left,
-							  Key right,
-							  Key jump,
-							  Key bomb,
-							  Key pause)
+	                                     Key up,
+	                                     Key down,
+	                                     Key left,
+	                                     Key right,
+	                                     Key jump,
+	                                     Key bomb,
+	                                     Key pause)
 		: WAL::Component(entity), keyJump(jump), keyBomb(bomb), keyPause(pause),
-								  keyRight(right), keyLeft(left), keyUp(up), keyDown(down)
+		  keyRight(right), keyLeft(left), keyUp(up), keyDown(down)
 	{}
 
 	WAL::Component *KeyboardComponent::clone(WAL::Entity &entity) const

--- a/sources/Component/Keyboard/KeyboardComponent.cpp
+++ b/sources/Component/Keyboard/KeyboardComponent.cpp
@@ -7,8 +7,16 @@
 
 namespace BBM
 {
-	KeyboardComponent::KeyboardComponent(WAL::Entity &entity)
-		: WAL::Component(entity)
+	KeyboardComponent::KeyboardComponent(WAL::Entity &entity,
+							  Key up,
+							  Key down,
+							  Key left,
+							  Key right,
+							  Key jump,
+							  Key bomb,
+							  Key pause)
+		: WAL::Component(entity), keyJump(jump), keyBomb(bomb), keyPause(pause),
+								  keyRight(right), keyLeft(left), keyUp(up), keyDown(down)
 	{}
 
 	WAL::Component *KeyboardComponent::clone(WAL::Entity &entity) const

--- a/sources/Component/Keyboard/KeyboardComponent.hpp
+++ b/sources/Component/Keyboard/KeyboardComponent.hpp
@@ -33,9 +33,16 @@ namespace BBM
 
 			//! @inherit
 			WAL::Component *clone(WAL::Entity &entity) const override;
-
-			//! @brief Create a new keyboard component using default keys.
-			explicit KeyboardComponent(WAL::Entity &entity);
+		
+			//! @brief Create a new keyboard component using custom keys.
+			KeyboardComponent(WAL::Entity &entity,
+							  Key up = KEY_W,
+							  Key down = KEY_S,
+							  Key left = KEY_A,
+							  Key right = KEY_D,
+							  Key jump = KEY_SPACE,
+							  Key bomb = KEY_E,
+							  Key pause = RAY::Controller::Keyboard::Key::KEY_ESCAPE);
 
 			//! @brief A Keyboard component is copy constructable.
 			KeyboardComponent(const KeyboardComponent &) = default;

--- a/sources/Component/Keyboard/KeyboardComponent.hpp
+++ b/sources/Component/Keyboard/KeyboardComponent.hpp
@@ -15,42 +15,42 @@ namespace BBM
 {
 	class KeyboardComponent : public WAL::Component
 	{
-		public:
-			//! @brief jump key
-			Key keyJump = KEY_SPACE;
-			//! @brief bomb key
-			Key keyBomb = KEY_E;
-			//! @brief pause key
-			Key keyPause = RAY::Controller::Keyboard::Key::KEY_ESCAPE;
-			//! @brief move right key
-			Key keyRight = KEY_D;
-			//! @brief move left key
-			Key keyLeft = KEY_A;
-			//! @brief move up key
-			Key keyUp = KEY_W;
-			//! @brief move down key
-			Key keyDown = KEY_S;
+	public:
+		//! @brief jump key
+		Key keyJump = KEY_SPACE;
+		//! @brief bomb key
+		Key keyBomb = KEY_E;
+		//! @brief pause key
+		Key keyPause = RAY::Controller::Keyboard::Key::KEY_ESCAPE;
+		//! @brief move right key
+		Key keyRight = KEY_D;
+		//! @brief move left key
+		Key keyLeft = KEY_A;
+		//! @brief move up key
+		Key keyUp = KEY_W;
+		//! @brief move down key
+		Key keyDown = KEY_S;
 
-			//! @inherit
-			WAL::Component *clone(WAL::Entity &entity) const override;
-		
-			//! @brief Create a new keyboard component using custom keys.
-			KeyboardComponent(WAL::Entity &entity,
-							  Key up = KEY_W,
-							  Key down = KEY_S,
-							  Key left = KEY_A,
-							  Key right = KEY_D,
-							  Key jump = KEY_SPACE,
-							  Key bomb = KEY_E,
-							  Key pause = RAY::Controller::Keyboard::Key::KEY_ESCAPE);
+		//! @inherit
+		WAL::Component *clone(WAL::Entity &entity) const override;
 
-			//! @brief A Keyboard component is copy constructable.
-			KeyboardComponent(const KeyboardComponent &) = default;
+		//! @brief Create a new keyboard component using custom keys.
+		KeyboardComponent(WAL::Entity &entity,
+		                  Key up = KEY_W,
+		                  Key down = KEY_S,
+		                  Key left = KEY_A,
+		                  Key right = KEY_D,
+		                  Key jump = KEY_SPACE,
+		                  Key bomb = KEY_E,
+		                  Key pause = RAY::Controller::Keyboard::Key::KEY_ESCAPE);
 
-			//! @brief default destructor
-			~KeyboardComponent() override = default;
+		//! @brief A Keyboard component is copy constructable.
+		KeyboardComponent(const KeyboardComponent &) = default;
 
-			//! @brief A Keyboard component can't be assigned
-			KeyboardComponent &operator=(const KeyboardComponent &) = delete;
+		//! @brief default destructor
+		~KeyboardComponent() override = default;
+
+		//! @brief A Keyboard component can't be assigned
+		KeyboardComponent &operator=(const KeyboardComponent &) = delete;
 	};
 }

--- a/sources/Component/Keyboard/KeyboardComponent.hpp
+++ b/sources/Component/Keyboard/KeyboardComponent.hpp
@@ -21,7 +21,7 @@ namespace BBM
 		//! @brief bomb key
 		Key keyBomb = KEY_E;
 		//! @brief pause key
-		Key keyPause = RAY::Controller::Keyboard::Key::KEY_ESCAPE;
+		Key keyPause = KEY_ESCAPE;
 		//! @brief move right key
 		Key keyRight = KEY_D;
 		//! @brief move left key
@@ -35,14 +35,14 @@ namespace BBM
 		WAL::Component *clone(WAL::Entity &entity) const override;
 
 		//! @brief Create a new keyboard component using custom keys.
-		KeyboardComponent(WAL::Entity &entity,
+		explicit KeyboardComponent(WAL::Entity &entity,
 		                  Key up = KEY_W,
 		                  Key down = KEY_S,
 		                  Key left = KEY_A,
 		                  Key right = KEY_D,
 		                  Key jump = KEY_SPACE,
 		                  Key bomb = KEY_E,
-		                  Key pause = RAY::Controller::Keyboard::Key::KEY_ESCAPE);
+		                  Key pause = KEY_ESCAPE);
 
 		//! @brief A Keyboard component is copy constructable.
 		KeyboardComponent(const KeyboardComponent &) = default;

--- a/sources/Map/Map.cpp
+++ b/sources/Map/Map.cpp
@@ -60,7 +60,7 @@ namespace BBM
 						.addComponent<CollisionComponent>(
 							WAL::Callback<WAL::Entity &, const WAL::Entity &, CollisionComponent::CollidedAxis>(),
 							&MapGenerator::wallCollide, 0.25, .75)
-						.addComponent<Drawable3DComponent, RAY3D::Model>(unbreakableObj,
+						.addComponent<Drawable3DComponent, RAY3D::Model>(unbreakableObj, false,
 						                                                 std::make_pair(MAP_DIFFUSE, unbreakablePng));
 				}
 			}
@@ -78,7 +78,7 @@ namespace BBM
 			.addComponent<CollisionComponent>(
 				WAL::Callback<WAL::Entity &, const WAL::Entity &, CollisionComponent::CollidedAxis>(),
 				&MapGenerator::wallCollide, Vector3f(-(width + 1) / 2 , 0.25, 0.25), Vector3f(width + 1, 2, 0.75))
-			.addComponent<Drawable3DComponent, RAY3D::Model>(unbreakableObj,
+			.addComponent<Drawable3DComponent, RAY3D::Model>(unbreakableObj, false,
 			                                                 std::make_pair(MAP_DIFFUSE, unbreakablePnj),
 			                                                 RAY::Vector3(width + 3, 1, 1));
 		scene->addEntity("Upper Wall")
@@ -87,7 +87,7 @@ namespace BBM
 			.addComponent<CollisionComponent>(
 				WAL::Callback<WAL::Entity &, const WAL::Entity &, CollisionComponent::CollidedAxis>(),
 				&MapGenerator::wallCollide, Vector3f(-(width + 1) / 2 , 0.25, 0.25), Vector3f(width + 1, 2, 0.75))
-			.addComponent<Drawable3DComponent, RAY3D::Model>(unbreakableObj,
+			.addComponent<Drawable3DComponent, RAY3D::Model>(unbreakableObj, false, 
 			                                                 std::make_pair(MAP_DIFFUSE, unbreakablePnj),
 			                                                 RAY::Vector3(width + 3, 1, 1));
 		scene->addEntity("Left Wall")
@@ -96,7 +96,7 @@ namespace BBM
 			.addComponent<CollisionComponent>(
 				WAL::Callback<WAL::Entity &, const WAL::Entity &, CollisionComponent::CollidedAxis>(),
 				&MapGenerator::wallCollide, Vector3f(0.25, 0.25, -(height + 1) / 2 ), Vector3f(0.75, 2, height + 1))
-			.addComponent<Drawable3DComponent, RAY3D::Model>(unbreakableObj,
+			.addComponent<Drawable3DComponent, RAY3D::Model>(unbreakableObj, false, 
 			                                                 std::make_pair(MAP_DIFFUSE, unbreakablePnj),
 			                                                 RAY::Vector3(1, 1, height + 1));
 		scene->addEntity("Right Wall")
@@ -104,7 +104,7 @@ namespace BBM
 			.addComponent<CollisionComponent>(
 				WAL::Callback<WAL::Entity &, const WAL::Entity &, CollisionComponent::CollidedAxis>(),
 				&MapGenerator::wallCollide, Vector3f(0.25, 0.25, -(height + 1) / 2 ), Vector3f(0.75, 2, height + 1))
-			.addComponent<Drawable3DComponent, RAY3D::Model>(unbreakableObj,
+			.addComponent<Drawable3DComponent, RAY3D::Model>(unbreakableObj, false, 
 			                                                 std::make_pair(MAP_DIFFUSE, unbreakablePnj),
 			                                                 RAY::Vector3(1, 1, height + 1));
 	}
@@ -119,7 +119,7 @@ namespace BBM
 				if (map[std::make_tuple(i, 0, j)] != HOLE && map[std::make_tuple(i, -1, j)] != BUMPER)
 					scene->addEntity("Unbreakable Wall")
 						.addComponent<PositionComponent>(Vector3f(i, -1, j))
-						.addComponent<Drawable3DComponent, RAY3D::Model>(floorObj,
+						.addComponent<Drawable3DComponent, RAY3D::Model>(floorObj, false,
 						                                                 std::make_pair(MAP_DIFFUSE, floorPng));
 			}
 		}
@@ -154,7 +154,7 @@ namespace BBM
 			.addComponent<CollisionComponent>(
 				WAL::Callback<WAL::Entity &, const WAL::Entity &, CollisionComponent::CollidedAxis>(),
 				&MapGenerator::wallCollide, 0.25, .75)
-			.addComponent<Drawable3DComponent, RAY3D::Model>(breakableObj, std::make_pair(MAP_DIFFUSE, breakablePng));
+			.addComponent<Drawable3DComponent, RAY3D::Model>(breakableObj, false, std::make_pair(MAP_DIFFUSE, breakablePng));
 	}
 
 	void MapGenerator::createFloor(Vector3f coords, std::shared_ptr<WAL::Scene> scene)
@@ -165,7 +165,7 @@ namespace BBM
 		scene->addEntity("Floor")
 			.addComponent<PositionComponent>(Vector3f(coords))
 			//.addComponent<CollisionComponent>(1)
-			.addComponent<Drawable3DComponent, RAY3D::Model>(floorObj, std::make_pair(MAP_DIFFUSE, floorPng));
+			.addComponent<Drawable3DComponent, RAY3D::Model>(floorObj, false, std::make_pair(MAP_DIFFUSE, floorPng));
 	}
 
 	void MapGenerator::createUpperFloor(Vector3f coords, std::shared_ptr<WAL::Scene> scene)
@@ -175,7 +175,7 @@ namespace BBM
 
 		scene->addEntity("Upper Floor")
 			.addComponent<PositionComponent>(Vector3f(coords))
-			.addComponent<Drawable3DComponent, RAY3D::Model>(floorObj, std::make_pair(MAP_DIFFUSE, floorPng));
+			.addComponent<Drawable3DComponent, RAY3D::Model>(floorObj, false, std::make_pair(MAP_DIFFUSE, floorPng));
 	}
 
 
@@ -190,7 +190,7 @@ namespace BBM
 			.addComponent<CollisionComponent>(
 				WAL::Callback<WAL::Entity &, const WAL::Entity &, CollisionComponent::CollidedAxis>(),
 				&MapGenerator::wallCollide, 0.25, .75)
-			.addComponent<Drawable3DComponent, RAY3D::Model>(UnbreakableObj,
+			.addComponent<Drawable3DComponent, RAY3D::Model>(UnbreakableObj, false,
 			                                                 std::make_pair(MAP_DIFFUSE, UnbreakablePng));
 	}
 
@@ -206,9 +206,9 @@ namespace BBM
 		holeEntity.addComponent<PositionComponent>(Vector3f(coords.x, coords.y - 1, coords.z));
 
 		if (coords.y == 0)
-			holeEntity.addComponent<Drawable3DComponent, RAY3D::Model>(holeObj, std::make_pair(MAP_DIFFUSE, holePng));
+			holeEntity.addComponent<Drawable3DComponent, RAY3D::Model>(holeObj, false, std::make_pair(MAP_DIFFUSE, holePng));
 		else
-			holeEntity.addComponent<Drawable3DComponent, RAY3D::Model>(secondFloorObj,
+			holeEntity.addComponent<Drawable3DComponent, RAY3D::Model>(secondFloorObj, false,
 			                                                           std::make_pair(MAP_DIFFUSE, secondFloorPng));
 		/*.addComponent<CollisionComponent>([](WAL::Entity &other, const WAL::Entity &entity) {
 			if (other.hasComponent<HealthComponent>()) {
@@ -225,7 +225,7 @@ namespace BBM
 
 		scene->addEntity("Bumper Block")
 			.addComponent<PositionComponent>(Vector3f(coords.x, coords.y, coords.z))
-			.addComponent<Drawable3DComponent, RAY3D::Model>(bumperObj, std::make_pair(MAP_DIFFUSE, bumperPng));
+			.addComponent<Drawable3DComponent, RAY3D::Model>(bumperObj, false, std::make_pair(MAP_DIFFUSE, bumperPng));
 		/* .addComponent<CollisionComponent>([](const WAL::Entity &entity, WAL::Entity &other) {
 			if (other.hasComponent<MovableComponent>()) {
 				auto &movable = other.getComponent<MovableComponent>();

--- a/sources/Runner/Runner.cpp
+++ b/sources/Runner/Runner.cpp
@@ -527,7 +527,7 @@ namespace BBM
 		};
 		scene->addEntity("player")
 			.addComponent<PositionComponent>()
-			.addComponent<Drawable3DComponent, RAY3D::Model>("assets/player/player.iqm", std::make_pair(MAP_DIFFUSE, "assets/player/blue.png"))
+			.addComponent<Drawable3DComponent, RAY3D::Model>("assets/player/player.iqm", true, std::make_pair(MAP_DIFFUSE, "assets/player/blue.png"))
 			.addComponent<ControllableComponent>()
 			.addComponent<AnimatorComponent>()
 			.addComponent<KeyboardComponent>()

--- a/sources/System/BombHolder/BombHolderSystem.cpp
+++ b/sources/System/BombHolder/BombHolderSystem.cpp
@@ -56,7 +56,7 @@ namespace BBM
 			.addComponent<TimerComponent>(BombHolderSystem::explosionTimer, &BombHolderSystem::_bombExplosion)
 //			.addComponent<CollisionComponent>(WAL::Callback<WAL::Entity &, const WAL::Entity &, CollisionComponent::CollidedAxis>(),
 //			                                  &MapGenerator::wallCollide, 0.25, .75)
-			.addComponent<Drawable3DComponent, RAY3D::Model>("assets/bombs/bomb.obj",
+			.addComponent<Drawable3DComponent, RAY3D::Model>("assets/bombs/bomb.obj", false,
 				std::make_pair(MAP_DIFFUSE, "assets/bombs/bomb_normal.png"));
 	}
 


### PR DESCRIPTION
## Proposed changes

Player's models are now differents instances (load) of the same file, which allows animations independency

## Information
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking changes


- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation
