### PR TITLE
Bombs fix

### DIFF
--- a/sources/Component/Bomb/BasicBombComponent.cpp
+++ b/sources/Component/Bomb/BasicBombComponent.cpp
@@ -4,17 +4,19 @@
 
 #include "BasicBombComponent.hpp"
 
+#include <utility>
+
 namespace BBM
 {
-	BasicBombComponent::BasicBombComponent(WAL::Entity &entity, int damage, int explosionRadius, unsigned ownerID)
-			: WAL::Component(entity),
-			damage(damage),
-			explosionRadius(explosionRadius),
-			ownerID(ownerID)
+	BasicBombComponent::BasicBombComponent(WAL::Entity &entity, int damage, int explosionRadius, std::vector<unsigned> ignored)
+		: WAL::Component(entity),
+		damage(damage),
+		explosionRadius(explosionRadius),
+		ignoredEntities(std::move(ignored))
 	{}
 
 	WAL::Component *BasicBombComponent::clone(WAL::Entity &entity) const
 	{
-		return new BasicBombComponent(entity, this->damage, this->explosionRadius, this->ownerID);
+		return new BasicBombComponent(entity, this->damage, this->explosionRadius, this->ignoredEntities);
 	}
 }

--- a/sources/Component/Bomb/BasicBombComponent.hpp
+++ b/sources/Component/Bomb/BasicBombComponent.hpp
@@ -19,16 +19,14 @@ namespace BBM
 		const int explosionRadius = 3;
 		//! @brief The damage made by the explosion on an entity
 		const int damage = 1;
-		//! @brief The ID of the owner.
-		unsigned ownerID;
-		//! @brief Should collisions with the owner be disabled.²
-		bool ignoreOwner = true;
+		//! @brief The list of IDs of ignored entities.
+		std::vector<unsigned> ignoredEntities;
 
 		//! @inherit
 		WAL::Component *clone(WAL::Entity &entity) const override;
 
 		//! @brief A component can't be instantiated, it should be derived.
-		explicit BasicBombComponent(WAL::Entity &entity, int damage, int explosionRadius, unsigned ownerID);
+		explicit BasicBombComponent(WAL::Entity &entity, int damage, int explosionRadius, std::vector<unsigned> ignored);
 
 		//! @brief A component can't be instantiated, it should be derived.
 		BasicBombComponent(const BasicBombComponent &) = default;

--- a/sources/System/Bomb/BombSystem.cpp
+++ b/sources/System/Bomb/BombSystem.cpp
@@ -14,15 +14,16 @@ namespace BBM
 	void BombSystem::onUpdate(WAL::ViewEntity<BasicBombComponent, PositionComponent> &entity, std::chrono::nanoseconds dtime)
 	{
 		auto &bomb = entity.get<BasicBombComponent>();
-		if (!bomb.ignoreOwner)
+
+		if (bomb.ignoredEntities.empty())
 			return;
+
 		auto &pos = entity.get<PositionComponent>();
 		for (auto &[owner, ownerPos, _] : this->_wal.getScene()->view<PositionComponent, BombHolderComponent>()) {
-			if (owner.getUid() != bomb.ownerID)
-				continue;
 			if (pos.position.distance(ownerPos.position) >= 1.1) {
-				bomb.ignoreOwner = false;
-				return;
+				bomb.ignoredEntities.erase(
+					std::remove(bomb.ignoredEntities.begin(), bomb.ignoredEntities.end(), owner.getUid()),
+					bomb.ignoredEntities.end());
 			}
 		}
 	}

--- a/sources/System/BombHolder/BombHolderSystem.cpp
+++ b/sources/System/BombHolder/BombHolderSystem.cpp
@@ -125,7 +125,7 @@ namespace BBM
 		}
 
 		this->_wal.getScene()->scheduleNewEntity("Bomb")
-			.addComponent<PositionComponent>(position.round())
+			.addComponent<PositionComponent>(position)
 			.addComponent<HealthComponent>(1, [](WAL::Entity &entity, WAL::Wal &wal) {
 				// the bomb explode when hit
 				entity.scheduleDeletion();
@@ -180,16 +180,21 @@ namespace BBM
 		auto &position = entity.get<PositionComponent>();
 		auto &controllable = entity.get<ControllableComponent>();
 
-		if (controllable.bomb && holder.bombCount > 0) {
-			holder.bombCount--;
-			this->_spawnBomb(position.position, holder);
-		}
 		if (holder.bombCount < holder.maxBombCount) {
 			holder.nextBombRefill -= dtime;
 			if (holder.nextBombRefill <= 0ns) {
 				holder.nextBombRefill = holder.refillRate;
 				holder.bombCount++;
 			}
+		}
+		if (controllable.bomb && holder.bombCount > 0) {
+			auto spawnPos = position.position.round();
+			for (auto &[entity, pos, _] : this->_wal.getScene()->view<PositionComponent, BasicBombComponent>()) {
+				if (pos.position == spawnPos)
+					return;
+			}
+			holder.bombCount--;
+			this->_spawnBomb(spawnPos, holder);
 		}
 	}
 }

--- a/sources/System/BombHolder/BombHolderSystem.hpp
+++ b/sources/System/BombHolder/BombHolderSystem.hpp
@@ -35,7 +35,7 @@ namespace BBM
 	{
 	private:
 		//! @brief Spawn a bomb at the specified position.
-		void _spawnBomb(Vector3f position, BombHolderComponent &holder, unsigned id);
+		void _spawnBomb(Vector3f position, BombHolderComponent &holder);
 
 		//! @brief Spawn a bomb at the specified position.
 		static void _dispatchExplosion(const Vector3f &position,


### PR DESCRIPTION
## Proposed changes

Players can now move if a bomb is placed under their feet.
Bombs can't be placed on blocks where a bomb already exist.

## Information
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Non-breaking changes

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
