### PR TITLE
Fixes

### DIFF
--- a/sources/Runner/GameScene.cpp
+++ b/sources/Runner/GameScene.cpp
@@ -121,7 +121,9 @@ namespace BBM
 					return;
 				entity.getComponent<ControllableComponent>().disabled = true;
 				entity.addComponent<TimerComponent>(1s, [](WAL::Entity &ent, WAL::Wal &) {
-					ent.scheduleDeletion();
+					ent.removeComponent<SoundComponent>();
+					ent.removeComponent<CollisionComponent>();
+					ent.removeComponent<PositionComponent>();
 				});
 			});
 	}

--- a/sources/System/Gamepad/GamepadSystem.cpp
+++ b/sources/System/Gamepad/GamepadSystem.cpp
@@ -17,7 +17,7 @@ namespace BBM
 		: System(wal)
 	{}
 
-	void GamepadSystem::onFixedUpdate(WAL::ViewEntity<GamepadComponent, ControllableComponent> &entity)
+	void GamepadSystem::onUpdate(WAL::ViewEntity<GamepadComponent, ControllableComponent> &entity, std::chrono::nanoseconds)
 	{
 		const auto &gamepadComponent = entity.get<GamepadComponent>();
 		auto &controllable = entity.get<ControllableComponent>();
@@ -34,6 +34,8 @@ namespace BBM
 
 		for (auto key : keyPressedMap)
 			key.second = controllable.fastClick ? gamepad.isDown(key.first) : gamepad.isPressed(key.first);
+		if (gamepad.isPressed(GAMEPAD_BUTTON_MIDDLE_LEFT) || gamepad.isPressed(GAMEPAD_BUTTON_MIDDLE_RIGHT))
+			controllable.pause = true;
 		controllable.move.x = gamepad.getAxisValue(gamepadComponent.LeftStickX) * -1;
 		controllable.move.y = gamepad.getAxisValue(gamepadComponent.LeftStickY) * -1;
 		controllable.move.x -= static_cast<float>(gamepad.isDown(gamepadComponent.keyRight));

--- a/sources/System/Gamepad/GamepadSystem.hpp
+++ b/sources/System/Gamepad/GamepadSystem.hpp
@@ -16,7 +16,7 @@ namespace BBM
 	{
 	public:
 		//! @inherit
-		void onFixedUpdate(WAL::ViewEntity<GamepadComponent, ControllableComponent> &entity) override;
+		void onUpdate(WAL::ViewEntity<GamepadComponent, ControllableComponent> &entity, std::chrono::nanoseconds) override;
 
 		//! @brief A default constructor
 		explicit GamepadSystem(WAL::Wal &wal);

--- a/sources/System/Renderer/CameraSystem.cpp
+++ b/sources/System/Renderer/CameraSystem.cpp
@@ -92,6 +92,5 @@ namespace BBM
 		newCameraPos.y = maxDist;
 		newCameraPos.z -= newCameraPos.z > 1 ? 1 : 0;
 		pos.position += (newCameraPos.abs() - pos.position.abs()) / 10;
-
 	}
 }


### PR DESCRIPTION
## Proposed changes

Fix #239 and make the menues easier to navigate with a gamepad (also allow a gamepad to go to the pause menu)

## Information
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Non-breaking changes

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation